### PR TITLE
package-dependents 1.2.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *~
 *.log
 node_modules
+*.env

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -7,6 +7,7 @@ Get the dependents of a given packages. The callback function is called with
 an error and an array of objects.
 
 #### Params
+
 - **String** `name`: The package name.
 - **String** `version`: The package version (default: `"latest"`).
 - **Function** `callback`: The callback function.

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,8 +1,8 @@
-// Dependencies
-var GetDependents = require('npm-get-dependents')
-  , SameTime = require("same-time")
-  , PackageJson = require("package-json")
-  ;
+"use strict"
+
+const GetDependents = require('npm-pack-dependents')
+    , SameTime = require("same-time")
+    , PackageJson = require("package-json")
 
 /**
  * PackageDependents
@@ -17,23 +17,23 @@ var GetDependents = require('npm-get-dependents')
  */
 function PackageDependents(name, version, callback) {
     if (typeof version === "function") {
-        callback = version;
-        version = "latest";
+        callback = version
+        version = "latest"
     }
     GetDependents(name, function(err, packages) {
-        if (err) { return callback(err); }
+        if (err) { return callback(err) }
         SameTime(packages.map(function (c) {
             return function (fn) {
                 PackageJson(c, version).then(function (json) {
-                    fn(null, json);
+                    fn(null, json)
                 }).catch(function (err) {
-                    fn(err);
-                });
-            };
+                    fn(err)
+                })
+            }
         }), function (err, packages) {
-            callback(err, packages || []);
-        });
-    });
+            callback(err, packages || [])
+        })
+    })
 }
 
-module.exports = PackageDependents;
+module.exports = PackageDependents

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "package-dependents",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Get the npm dependents of a given package.",
   "main": "lib/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "example": "example"
   },
   "dependencies": {
-    "npm-get-dependents": "^1.0.0",
+    "npm-pack-dependents": "0.0.0",
     "package-json": "^2.2.1",
     "same-time": "^2.0.0"
   },


### PR DESCRIPTION
Use `npm-pack-dependents`

The old dependency was buggy and not working anymore.

Remove semicolons